### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Mars Photos
 ==================================
 
-Mars Photos app is a demo app that shows actual images of Mar's surface. These images are
+Mars Photos app is a demo app that shows actual images of Mars' surface. These images are
 real-life photos from Mars captured by NASA's Mars rovers. The data is stored on a Web server
 as a REST web service.
 


### PR DESCRIPTION
Fix typo.

There is some conversation on it at https://english.stackexchange.com/questions/147905/marss-or-mars

I edited the readme over github's web based editor. It probably added a line break or something else on the last line. I didn't change anything myself.